### PR TITLE
feat: add support for AudioMouse in MusicAssistant

### DIFF
--- a/aiojellyfin/__init__.py
+++ b/aiojellyfin/__init__.py
@@ -1,9 +1,7 @@
 """A simple library for talking to a Jellyfin server."""
 
-from tkinter.constants import TRUE
 import urllib
 from typing import Final, cast
-from xxlimited import Str
 
 from mashumaro.codecs.basic import BasicDecoder
 

--- a/aiojellyfin/__init__.py
+++ b/aiojellyfin/__init__.py
@@ -1,5 +1,6 @@
 """A simple library for talking to a Jellyfin server."""
 
+from tkinter.constants import TRUE
 import urllib
 from typing import Final, cast
 from xxlimited import Str
@@ -157,7 +158,7 @@ class Connection:
         track_id: str,
         limit: int | None = None,
         fields: list[ItemFields] | None = None,
-        enable_images: bool | None = None
+        enable_images: bool = True
     ) -> MediaItems[Track]:
         """Return similar tracks."""
         params: dict[str, str | list[str]] = {}

--- a/aiojellyfin/__init__.py
+++ b/aiojellyfin/__init__.py
@@ -2,6 +2,7 @@
 
 import urllib
 from typing import Final, cast
+from xxlimited import Str
 
 from mashumaro.codecs.basic import BasicDecoder
 
@@ -156,18 +157,22 @@ class Connection:
         track_id: str,
         limit: int | None = None,
         fields: list[ItemFields] | None = None,
+        enable_images: bool | None = None
     ) -> MediaItems[Track]:
         """Return similar tracks."""
-        params: dict[str, str] = {}
+        params: dict[str, str | list[str]] = {}
 
         if limit:
             params["limit"] = str(limit)
 
         if fields:
-            params["fields"] = ",".join(f.value for f in fields)
+            params["fields"] = [f.value for f in fields]
+
+        if enable_images:
+            params["enableImages"] = str(enable_images)
 
         resp = await self._session.get_json(
-            f"/Items/{track_id}/Similar",
+            f"/Items/{track_id}/InstantMix",
             params=params or {},
         )
         return self._tracks_decoder.decode(resp)

--- a/aiojellyfin/session.py
+++ b/aiojellyfin/session.py
@@ -63,7 +63,7 @@ class Session:
         self._user_id = user_id
         self._access_token = access_token
 
-    async def get_json(self, url: str, params: Mapping[str, str]) -> dict[str, Any]:
+    async def get_json(self, url: str, params: Mapping[str, str | list[str]]) -> dict[str, Any]:
         """Call a Jellyfin API and retrieve the JSON response."""
         try:
             resp = await self._session.get(


### PR DESCRIPTION
By changing the endpoint to `Item/{itemId}/InstantMix` for fetching similar tracks, this PR adds support for the [AudioMouse-AI Plugin](https://github.com/NeptuneHub/audiomuse-ai-plugin). As a result, the radio mode in Music Assistant now returns tracks that are more naturally similar, leveraging AudioMouse-AI’s sonic analysis.

Because the AudioMouse-AI plugin overrides the InstantMix endpoint and only supports query parameter arrays in the format `?fields=field1&field=field2&...` (not `?fields=field1,field2,...`), this PR adds support for lists of strings in the static typing for parameters in get_json, allowing aiohttp to automatically convert them into the correct query format.