### PR TITLE
Add set_favorite method to Connection

### DIFF
--- a/aiojellyfin/__init__.py
+++ b/aiojellyfin/__init__.py
@@ -172,6 +172,14 @@ class Connection:
         )
         return self._tracks_decoder.decode(resp)
 
+    async def set_favorite(self, item_id: str, favorite: bool) -> None:
+        """Mark or unmark an item as a favorite for the current user."""
+        url = f"/Users/{self._user_id}/FavoriteItems/{item_id}"
+        if favorite:
+            await self._session.post_json(url)
+        else:
+            await self._session.delete_json(url)
+
     def _build_url(self, url: str, params: dict[str, str | int]) -> str:
         assert url.startswith("/")
 

--- a/aiojellyfin/session.py
+++ b/aiojellyfin/session.py
@@ -63,17 +63,38 @@ class Session:
         self._user_id = user_id
         self._access_token = access_token
 
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Content-Type": "application/json",
+            "User-Agent": self._session_config.user_agent,
+            "Authorization": self._session_config.authentication_header(self._access_token),
+        }
+
+    async def post_json(self, url: str) -> None:
+        """Call a Jellyfin API with POST."""
+        await self._session.post(
+            f"{self.base_url}{url}",
+            headers=self._headers(),
+            ssl=self._session_config.verify_ssl,
+            raise_for_status=True,
+        )
+
+    async def delete_json(self, url: str) -> None:
+        """Call a Jellyfin API with DELETE."""
+        await self._session.delete(
+            f"{self.base_url}{url}",
+            headers=self._headers(),
+            ssl=self._session_config.verify_ssl,
+            raise_for_status=True,
+        )
+
     async def get_json(self, url: str, params: Mapping[str, str]) -> dict[str, Any]:
         """Call a Jellyfin API and retrieve the JSON response."""
         try:
             resp = await self._session.get(
                 f"{self.base_url}{url}",
                 params=params,
-                headers={
-                    "Content-Type": "application/json",
-                    "User-Agent": self._session_config.user_agent,
-                    "Authorization": self._session_config.authentication_header(self._access_token),
-                },
+                headers=self._headers(),
                 ssl=self._session_config.verify_ssl,
                 raise_for_status=True,
             )

--- a/aiojellyfin/testing.py
+++ b/aiojellyfin/testing.py
@@ -162,6 +162,12 @@ class TestConnection(Connection):
         """Return suggested tracks."""
         return await self.tracks.search_term("thrown").request()
 
+    async def set_favorite(self, item_id: str, favorite: bool) -> None:
+        """Mark or unmark an item as a favorite."""
+        if item_id not in self._fixture.objects:
+            raise NotFound(item_id)
+        self._fixture.objects[item_id].setdefault("UserData", {})["IsFavorite"] = favorite
+
     async def get_similar_tracks(
         self,
         track_id: str,

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -156,3 +156,24 @@ async def test_get_suggestions(connection: Connection) -> None:
     tracks = await connection.get_suggested_tracks()
     assert len(tracks["Items"]) == 1
     assert tracks["Items"][0]["Name"] == "11 Thrown Away"
+
+
+async def test_set_favorite_track(connection: Connection) -> None:
+    """Make sure we can mark a track as a favorite."""
+    track_id = "54918f75ee8f6c8b8dc5efd680644f29"
+    track = await connection.get_track(track_id)
+    assert track["UserData"]["IsFavorite"] is False
+
+    await connection.set_favorite(track_id, True)
+    track = await connection.get_track(track_id)
+    assert track["UserData"]["IsFavorite"] is True
+
+
+async def test_unset_favorite_track(connection: Connection) -> None:
+    """Make sure we can unmark a track as a favorite."""
+    track_id = "54918f75ee8f6c8b8dc5efd680644f29"
+
+    await connection.set_favorite(track_id, True)
+    await connection.set_favorite(track_id, False)
+    track = await connection.get_track(track_id)
+    assert track["UserData"]["IsFavorite"] is False


### PR DESCRIPTION
Adds POST/DELETE support to Session and a set_favorite method on Connection that calls /Users/{userId}/FavoriteItems/{itemId}.

I intend to use this to implement favourites syncing with Music Assistant, so it's within the scope of this library.

Also adds a set_favorite stub to TestConnection for use in tests.